### PR TITLE
Add scammer command to ban users

### DIFF
--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -3,7 +3,7 @@ import re
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import Literal, Optional, Union
-from venv import logger
+import logging
 
 import discord
 from discord import app_commands, Interaction
@@ -12,6 +12,9 @@ from discord.ext import commands, tasks
 from bot.bot import WarnetBot
 from bot.cogs.ext.tcg.utils import send_missing_permission_error_embed
 from bot.config import MESSAGE_LOG_CHANNEL_ID
+
+
+logger = logging.getLogger(__name__)
 
 
 @commands.guild_only()

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -3,6 +3,7 @@ import re
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import Literal, Optional, Union
+from venv import logger
 
 import discord
 from discord import app_commands, Interaction
@@ -121,6 +122,46 @@ class Admin(commands.GroupCog, group_name="admin"):
                 )
 
             await ctx.send(embed=embed)
+
+    @app_commands.command(name='scammer', description='Ban scammer account')
+    @app_commands.describe(
+        user='User to be banned.',
+    )
+    async def give_role_on_vc(
+        self,
+        interaction: Interaction,
+        user: discord.User,
+    ) -> None:
+        await interaction.response.defer()
+
+        if interaction.user.guild_permissions.administrator:
+            try:
+                await user.send(
+                    "You have been banned from *WARNET | Hoyoverse Indonesia* due to being a scammer. "
+                    "Please rejoin with this link: https://discord.gg/warnet"
+                )
+                await interaction.guild.ban(user, reason="Scammer account", delete_message_days=1)
+                await interaction.guild.unban(user, reason="Scammer account")
+            except Exception as e:
+                logger.error(f"Unexpected error while banning {user.name}.\n {e}")
+                return await interaction.followup.send(
+                    content=f"An unexpected error occurred: {e}", ephemeral=True
+                )
+
+            embed = discord.Embed(
+                color=discord.Color.green(),
+                title='✅ User successfully banned',
+                description=f"User {user.mention} has been banned from the server.",
+                timestamp=datetime.now(),
+            )
+            embed.set_footer(
+                text=f'Banned by {interaction.user.name}',
+                icon_url=interaction.user.display_avatar.url,
+            )
+            await interaction.followup.send(embed=embed)
+
+        else:
+            await send_missing_permission_error_embed(interaction)
 
     @app_commands.command(
         name='give-role-on-vc', description='Give a role to all members in a voice channel.'

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -129,7 +129,7 @@ class Admin(commands.GroupCog, group_name="admin"):
     @app_commands.describe(
         user='User to be banned.',
     )
-    async def give_role_on_vc(
+    async def ban_scammer(
         self,
         interaction: Interaction,
         user: Union[discord.Member, discord.User],

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -1,9 +1,9 @@
+import logging
 import os
 import re
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import Literal, Optional, Union
-import logging
 
 import discord
 from discord import app_commands, Interaction
@@ -12,7 +12,6 @@ from discord.ext import commands, tasks
 from bot.bot import WarnetBot
 from bot.cogs.ext.tcg.utils import send_missing_permission_error_embed
 from bot.config import MESSAGE_LOG_CHANNEL_ID
-
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +132,7 @@ class Admin(commands.GroupCog, group_name="admin"):
     async def give_role_on_vc(
         self,
         interaction: Interaction,
-        user: discord.User,
+        user: Union[discord.Member, discord.User],
     ) -> None:
         await interaction.response.defer()
 

--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -137,10 +137,11 @@ class Admin(commands.GroupCog, group_name="admin"):
         await interaction.response.defer()
 
         if interaction.user.guild_permissions.administrator:
+            guild_name = interaction.guild.name
             try:
                 await user.send(
-                    "You have been banned from *WARNET | Hoyoverse Indonesia* due to being a scammer. "
-                    "Please rejoin with this link: https://discord.gg/warnet"
+                    f"You have been banned from *{guild_name}* because you were identified as a scammer. "
+                    "You may rejoin using this link: https://discord.gg/warnet"
                 )
                 await interaction.guild.ban(user, reason="Scammer account", delete_message_days=1)
                 await interaction.guild.unban(user, reason="Scammer account")


### PR DESCRIPTION
Introduce a command that allows administrators to ban users identified as scammers, notifying them via direct message and providing a reason for the ban.