### PR TITLE
Ensure scheduled tasks only start if not already running in multiple cogs

### DIFF
--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -24,7 +24,8 @@ class Admin(commands.GroupCog, group_name="admin"):
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self._message_schedule_task.start()
+        if not self._message_schedule_task.is_running():
+            self._message_schedule_task.start()
 
     @commands.command()
     @commands.is_owner()
@@ -145,6 +146,9 @@ class Admin(commands.GroupCog, group_name="admin"):
                 )
                 await interaction.guild.ban(user, reason="Scammer account", delete_message_days=1)
                 await interaction.guild.unban(user, reason="Scammer account")
+                logger.info(
+                    f"Banned user {user.name} ({user.id}) by {interaction.user.name} ({interaction.user.id}) "
+                )
             except Exception as e:
                 logger.error(f"Unexpected error while banning {user.name}.\n {e}")
                 return await interaction.followup.send(

--- a/bot/cogs/booster.py
+++ b/bot/cogs/booster.py
@@ -18,7 +18,8 @@ class Booster(commands.Cog):
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self._monthly_booster.start()
+        if not self._monthly_booster.is_running():
+            self._monthly_booster.start()
 
     @commands.is_owner()
     @commands.command(name='boostermonthly')

--- a/bot/cogs/general.py
+++ b/bot/cogs/general.py
@@ -228,7 +228,8 @@ class General(commands.Cog):
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self._change_presence.start()
+        if not self._change_presence.is_running():
+            self._change_presence.start()
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx: commands.Context, error) -> None:

--- a/bot/cogs/genshin.py
+++ b/bot/cogs/genshin.py
@@ -19,7 +19,8 @@ class Genshin(commands.GroupCog, group_name="genshin"):
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self._rss.start()
+        if not self._rss.is_running():
+            self._rss.start()
 
     @tasks.loop(minutes=5)
     async def _rss(self) -> None:

--- a/bot/cogs/giveaway.py
+++ b/bot/cogs/giveaway.py
@@ -20,7 +20,8 @@ class Giveaway(commands.GroupCog, group_name='warnet-ga'):
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self._check_blacklist_ga.start()
+        if not self._check_blacklist_ga.is_running():
+            self._check_blacklist_ga.start()
 
     @app_commands.command(name='blacklist', description='Blacklist a user from giveaway')
     @app_commands.describe(

--- a/bot/cogs/temporary.py
+++ b/bot/cogs/temporary.py
@@ -20,7 +20,8 @@ class Temporary(commands.GroupCog, group_name='warnet-temp'):
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self._check_temprole.start()
+        if not self._check_temprole.is_running():
+            self._check_temprole.start()
 
     @app_commands.command(name='add', description='Adds a temprole to user')
     @app_commands.describe(


### PR DESCRIPTION
Prevent multiple instances of scheduled tasks from starting by checking if they are already running before initiating them.