### PR TITLE
Update DM confirmation error message in scammer ban command

### DIFF
--- a/bot/cogs/admin.py
+++ b/bot/cogs/admin.py
@@ -155,7 +155,7 @@ class Admin(commands.GroupCog, group_name="admin"):
             return
 
         guild_name = interaction.guild.name
-        err_msg = None
+        err_msg = "DM sent successfully."
         try:
             await user.send(
                 f"You have been banned from *{guild_name}* because you were identified as a scammer. "


### PR DESCRIPTION
Change the error message to indicate successful DM delivery when banning a scammer.