### PR TITLE
Adjust logging level and news check interval

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,8 +1,11 @@
 import asyncio
+import logging
 
 from bot import config
 from bot.bot import WarnetBot
 from bot.config.logger import setup_logger
+
+logging.getLogger("hoyolabrssfeeds").setLevel(logging.CRITICAL + 1)
 
 
 def main() -> None:

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -5,7 +5,7 @@ from bot import config
 from bot.bot import WarnetBot
 from bot.config.logger import setup_logger
 
-logging.getLogger("hoyolabrssfeeds").setLevel(logging.INFO + 1)
+logging.getLogger("hoyolabrssfeeds").setLevel(logging.ERROR)
 
 
 def main() -> None:

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -5,7 +5,7 @@ from bot import config
 from bot.bot import WarnetBot
 from bot.config.logger import setup_logger
 
-logging.getLogger("hoyolabrssfeeds").setLevel(logging.CRITICAL + 1)
+logging.getLogger("hoyolabrssfeeds").setLevel(logging.INFO + 1)
 
 
 def main() -> None:

--- a/bot/config/news.py
+++ b/bot/config/news.py
@@ -13,7 +13,7 @@ LAST_ID_HOYOLAB_NEWS_PATH = "bot/data/news/hoyolab.txt"
 TIMES_CHECK_UPDATE = [
     datetime.time(hour=h, minute=m, tzinfo=datetime.UTC)
     for h in range(24)
-    for m in range(7, 60, 10)
+    for m in range(2, 60, 10)
 ]
 
 TAG_COLOR_MAP = {


### PR DESCRIPTION
Change the logging level for hoyolabrssfeeds to reduce verbosity and update the news check interval to check every minutes 2 instead of every minutes 7.